### PR TITLE
Simplify to K=1 and somewhat punt consistency policies to the application

### DIFF
--- a/draft-group-privacypass-k-check.md
+++ b/draft-group-privacypass-k-check.md
@@ -1,6 +1,6 @@
 ---
-title: "The HTTP Mirror Protocol and its use for Resource Consistency Checks"
-abbrev: "Mirror and Consistency Checks"
+title: "Checking Resource Consistency with HTTP Mirrors"
+abbrev: "Checking Resource Consistency with HTTP Mirrors"
 category: std
 
 docname: draft-group-privacypass-k-check-latest


### PR DESCRIPTION
This partly addresses #11 and #14, but not entirely. We need some more considerations about timing correlations, application policies for dealing with consistency check failures, and so on before those issues are resolved.